### PR TITLE
Refactor home and watchlist pages into single state-based prototype flow

### DIFF
--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -480,3 +480,79 @@ footer {
 .animate-fadeIn {
   animation: fadeIn 0.4s ease both;
 }
+
+/* ============================================
+   DEMO STATE SWITCHER
+   ============================================ */
+
+.demo-state-panel {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 1200;
+}
+
+.demo-toggle-btn {
+  width: 48px;
+  height: 48px;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: rgba(15, 15, 22, 0.96);
+  color: var(--gold);
+  font-size: 1.15rem;
+  cursor: pointer;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.demo-toggle-btn:hover {
+  transform: translateY(-2px);
+  border-color: rgba(201, 168, 76, 0.35);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+.demo-controls {
+  width: 230px;
+  margin-top: 12px;
+  padding: 16px;
+  background: rgba(15, 15, 22, 0.96);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.45);
+}
+
+.demo-control-group + .demo-control-group {
+  margin-top: 14px;
+}
+
+.demo-label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.demo-select {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: 'Lato', sans-serif;
+  font-size: 0.92rem;
+  padding: 10px 12px;
+  outline: none;
+}
+
+.demo-select:focus {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 3px rgba(201, 168, 76, 0.1);
+}
+
+.demo-select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/frontend/static/css/watchlist_page.css
+++ b/frontend/static/css/watchlist_page.css
@@ -158,17 +158,8 @@
   margin-top: auto;
 }
 
-.watchlist-empty {
-  padding-top: 140px;
-}
-
 .watchlist-empty-hero {
   padding: 0 0 24px;
-}
-
-.watchlist-empty .page-container {
-  display: flex;
-  justify-content: center;
 }
 
 .watchlist-empty-card {
@@ -225,4 +216,53 @@
 
 .watchlist-empty-info .card-meta li::before {
   content: none;
+}
+.watchlist-state.hidden {
+  display: none;
+}
+
+#watchlist-empty-state {
+  padding-top: 140px;
+}
+
+#watchlist-empty-state > .page-section:first-child .page-container {
+  display: flex;
+  justify-content: center;
+}
+
+.page-section {
+  padding: 8px 0 80px;
+}
+.watchlist-page .watchlist-main {
+  padding-top: 96px;
+}
+
+.watchlist-page .navbar-cinema {
+  background: rgba(10, 10, 15, 0.96);
+  border-bottom: 1px solid var(--border);
+}
+
+.watchlist-hero {
+  padding: 24px 0 24px;
+}
+
+#watchlist-empty-state {
+  padding-top: 0;
+}
+
+#watchlist-empty-state > .page-section:first-child .page-container {
+  display: flex;
+  justify-content: center;
+}
+
+.watchlist-empty-hero {
+  padding: 24px 0 24px;
+}
+
+.page-section {
+  padding: 8px 0 56px;
+}
+
+.watchlist-grid {
+  margin-top: 8px;
 }

--- a/frontend/static/js/home_page.js
+++ b/frontend/static/js/home_page.js
@@ -1,0 +1,90 @@
+const STATE_KEYS = {
+  AUTH: 'movieStarDemoAuth',
+  WATCHLIST: 'movieStarDemoWatchlist'
+};
+
+const DEFAULT_STATES = {
+  AUTH: 'guest',
+  WATCHLIST: 'empty'
+};
+
+function initializeState() {
+  if (!localStorage.getItem(STATE_KEYS.AUTH)) {
+    localStorage.setItem(STATE_KEYS.AUTH, DEFAULT_STATES.AUTH);
+  }
+
+  if (!localStorage.getItem(STATE_KEYS.WATCHLIST)) {
+    localStorage.setItem(STATE_KEYS.WATCHLIST, DEFAULT_STATES.WATCHLIST);
+  }
+}
+
+function getAuthState() {
+  return localStorage.getItem(STATE_KEYS.AUTH) || DEFAULT_STATES.AUTH;
+}
+
+function setAuthState(state) {
+  localStorage.setItem(STATE_KEYS.AUTH, state);
+  updateAuthDisplay();
+}
+
+function updateAuthDisplay() {
+  const authState = getAuthState();
+  const guestElements = document.querySelectorAll('.auth-guest-only');
+  const loggedInElements = document.querySelectorAll('.auth-loggedin-only');
+
+  if (authState === 'logged-in') {
+    guestElements.forEach((el) => el.classList.add('hidden'));
+    loggedInElements.forEach((el) => el.classList.remove('hidden'));
+  } else {
+    guestElements.forEach((el) => el.classList.remove('hidden'));
+    loggedInElements.forEach((el) => el.classList.add('hidden'));
+  }
+}
+
+function setupLogoutButton() {
+  const logoutBtn = document.getElementById('home-logout-btn');
+
+  if (!logoutBtn) {
+    return;
+  }
+
+  logoutBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    setAuthState('guest');
+  });
+}
+
+function setupDemoStateControls() {
+  const toggleBtn = document.getElementById('demo-toggle-btn');
+  const controlsPanel = document.getElementById('demo-controls');
+  const authSelect = document.getElementById('auth-state-select');
+  const switcher = document.getElementById('demo-state-switcher');
+
+  if (!toggleBtn || !controlsPanel || !authSelect || !switcher) {
+    return;
+  }
+
+  authSelect.value = getAuthState();
+
+  toggleBtn.addEventListener('click', (event) => {
+    event.stopPropagation();
+    controlsPanel.classList.toggle('hidden');
+  });
+
+  authSelect.addEventListener('change', (event) => {
+    setAuthState(event.target.value);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!switcher.contains(event.target)) {
+      controlsPanel.classList.add('hidden');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initializeState();
+  updateAuthDisplay();
+  setupLogoutButton();
+  setupDemoStateControls();
+});

--- a/frontend/static/js/watchlist_page.js
+++ b/frontend/static/js/watchlist_page.js
@@ -1,0 +1,171 @@
+const STATE_KEYS = {
+  AUTH: 'movieStarDemoAuth',
+  WATCHLIST: 'movieStarDemoWatchlist'
+};
+
+const DEFAULT_STATES = {
+  AUTH: 'guest',
+  WATCHLIST: 'empty'
+};
+
+function initializeState() {
+  if (!localStorage.getItem(STATE_KEYS.AUTH)) {
+    localStorage.setItem(STATE_KEYS.AUTH, DEFAULT_STATES.AUTH);
+  }
+
+  if (!localStorage.getItem(STATE_KEYS.WATCHLIST)) {
+    localStorage.setItem(STATE_KEYS.WATCHLIST, DEFAULT_STATES.WATCHLIST);
+  }
+}
+
+function getAuthState() {
+  return localStorage.getItem(STATE_KEYS.AUTH) || DEFAULT_STATES.AUTH;
+}
+
+function getWatchlistState() {
+  return localStorage.getItem(STATE_KEYS.WATCHLIST) || DEFAULT_STATES.WATCHLIST;
+}
+
+function setAuthState(state) {
+  localStorage.setItem(STATE_KEYS.AUTH, state);
+  updatePageDisplay();
+}
+
+function setWatchlistState(state) {
+  localStorage.setItem(STATE_KEYS.WATCHLIST, state);
+  updatePageDisplay();
+}
+
+function updateAuthDisplay() {
+  const authState = getAuthState();
+  const guestElements = document.querySelectorAll('.auth-guest-only');
+  const loggedInElements = document.querySelectorAll('.auth-loggedin-only');
+
+  if (authState === 'logged-in') {
+    guestElements.forEach((el) => el.classList.add('hidden'));
+    loggedInElements.forEach((el) => el.classList.remove('hidden'));
+  } else {
+    guestElements.forEach((el) => el.classList.remove('hidden'));
+    loggedInElements.forEach((el) => el.classList.add('hidden'));
+  }
+}
+
+function updateEmptyStateContent(authState) {
+  const title = document.getElementById('watchlist-empty-title');
+  const copy = document.getElementById('watchlist-empty-copy');
+  const cta = document.getElementById('watchlist-empty-cta');
+
+  if (!title || !copy || !cta) {
+    return;
+  }
+
+  if (authState === 'guest') {
+    title.textContent = 'Log in to save your watchlist';
+    copy.textContent = 'Create an account or sign in to save movies and access your watchlist across the app.';
+    cta.textContent = 'Log In / Sign Up';
+    cta.setAttribute('href', 'auth.html');
+  } else {
+    title.textContent = 'Your Watchlist is Empty';
+    copy.textContent = 'Start building your watchlist by browsing movies and adding the ones you want to watch later.';
+    cta.textContent = 'Browse Movies';
+    cta.setAttribute('href', 'home_page.html');
+  }
+}
+
+function updatePageDisplay() {
+  const authState = getAuthState();
+  const watchlistState = getWatchlistState();
+
+  const emptyState = document.getElementById('watchlist-empty-state');
+  const filledState = document.getElementById('watchlist-filled-state');
+  const watchlistSelect = document.getElementById('watchlist-state-select');
+  const emptyInfoSection = document.getElementById('watchlist-empty-info-section');
+
+  updateAuthDisplay();
+  updateEmptyStateContent(authState);
+
+  if (!emptyState || !filledState) {
+    return;
+  }
+
+  if (authState === 'guest') {
+    emptyState.classList.remove('hidden');
+    filledState.classList.add('hidden');
+
+    if (emptyInfoSection) {
+      emptyInfoSection.classList.add('hidden');
+    }
+  } else if (watchlistState === 'empty') {
+    emptyState.classList.remove('hidden');
+    filledState.classList.add('hidden');
+
+    if (emptyInfoSection) {
+      emptyInfoSection.classList.remove('hidden');
+    }
+  } else {
+    emptyState.classList.add('hidden');
+    filledState.classList.remove('hidden');
+
+    if (emptyInfoSection) {
+      emptyInfoSection.classList.add('hidden');
+    }
+  }
+
+  if (watchlistSelect) {
+    watchlistSelect.disabled = authState === 'guest';
+  }
+}
+
+function setupLogoutButton() {
+  const logoutBtn = document.getElementById('watchlist-logout-btn');
+
+  if (!logoutBtn) {
+    return;
+  }
+
+  logoutBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    setAuthState('guest');
+  });
+}
+
+function setupDemoStateControls() {
+  const toggleBtn = document.getElementById('demo-toggle-btn');
+  const controlsPanel = document.getElementById('demo-controls');
+  const authSelect = document.getElementById('auth-state-select');
+  const watchlistSelect = document.getElementById('watchlist-state-select');
+  const switcher = document.getElementById('demo-state-switcher');
+
+  if (!toggleBtn || !controlsPanel || !authSelect || !watchlistSelect || !switcher) {
+    return;
+  }
+
+  authSelect.value = getAuthState();
+  watchlistSelect.value = getWatchlistState();
+
+  toggleBtn.addEventListener('click', (event) => {
+    event.stopPropagation();
+    controlsPanel.classList.toggle('hidden');
+  });
+
+  authSelect.addEventListener('change', (event) => {
+    setAuthState(event.target.value);
+  });
+
+  watchlistSelect.addEventListener('change', (event) => {
+    setWatchlistState(event.target.value);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!switcher.contains(event.target)) {
+      controlsPanel.classList.add('hidden');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initializeState();
+  updatePageDisplay();
+  setupLogoutButton();
+  setupDemoStateControls();
+});

--- a/frontend/templates/home_page.html
+++ b/frontend/templates/home_page.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Movie Star</title>
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
   <link rel="stylesheet" href="../static/css/style.css" />
   <link rel="stylesheet" href="../static/css/home_page.css" />
 </head>
@@ -16,9 +20,12 @@
         <li><a href="watchlist_page.html">Watch List</a></li>
         <li><a href="#reviews">Reviews</a></li>
       </ul>
-      <div class="nav-actions">
-        <a href="#" class="btn-ghost">Login</a>
-        <a href="#" class="btn-primary">Sign Up</a>
+      <div class="nav-actions" id="nav-actions">
+        <a href="auth.html" class="btn-ghost auth-guest-only">Login</a>
+        <a href="auth.html" class="btn-primary auth-guest-only">Sign Up</a>
+
+        <a href="my_profile.html" class="btn-primary auth-loggedin-only hidden">Profile</a>
+        <a href="home_page.html" id="home-logout-btn" class="btn-ghost auth-loggedin-only hidden">Logout</a>
       </div>
     </div>
   </nav>
@@ -27,7 +34,10 @@
     <div class="page-container hero-content">
       <p class="eyebrow">Your space for movie reviews and discovery</p>
       <h1 class="hero-heading">Discover & Review Your <span class="text-gold">Favorite Movies</span></h1>
-      <p class="hero-copy">Join a community of movie lovers. Explore new films, read reviews, and share your thoughts on the movies that stay in your head long after the credits roll.</p>
+      <p class="hero-copy">
+        Join a community of movie lovers. Explore new films, read reviews, and share your thoughts on the
+        movies that stay in your head long after the credits roll.
+      </p>
       <div class="hero-search">
         <div class="search-input-wrapper">
           <input type="text" class="field-input" placeholder="Search for movies..." />
@@ -160,5 +170,21 @@
   <footer>
     <div class="page-container footer-note">© 2026 Movie Star. Movie nights start here.</div>
   </footer>
+
+  <!-- Demo State Switcher -->
+  <div id="demo-state-switcher" class="demo-state-panel">
+    <button id="demo-toggle-btn" class="demo-toggle-btn" type="button" title="Toggle demo state controls">⚙️</button>
+    <div id="demo-controls" class="demo-controls hidden">
+      <div class="demo-control-group">
+        <label class="demo-label" for="auth-state-select">Auth State</label>
+        <select id="auth-state-select" class="demo-select">
+          <option value="guest">Guest</option>
+          <option value="logged-in">Logged In</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <script src="../static/js/home_page.js" defer></script>
 </body>
 </html>

--- a/frontend/templates/watchlist_page.html
+++ b/frontend/templates/watchlist_page.html
@@ -4,126 +4,200 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Movie Star | Watchlist</title>
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
   <link rel="stylesheet" href="../static/css/style.css" />
   <link rel="stylesheet" href="../static/css/watchlist_page.css" />
 </head>
-<body>
+<body class="watchlist-page">
   <nav class="navbar-cinema">
     <div class="page-container">
-      <a href="watchlist_page.html" class="nav-logo">Movie Star</a>
+      <a href="home_page.html" class="nav-logo">Movie Star</a>
       <ul class="nav-links">
-        <li><a href="home_page_logged_in.html">Home</a></li>
+        <li><a href="home_page.html">Home</a></li>
         <li><a href="watchlist_page.html" class="active">Watch List</a></li>
-        <li><a href="#reviews">Reviews</a></li>
+        <li><a href="home_page.html#reviews">Reviews</a></li>
       </ul>
+
       <div class="nav-actions">
-        <a href="#" class="btn-primary">Profile</a>
-        <a href="#" class="btn-ghost">Logout</a>
+        <a href="auth.html" class="btn-ghost auth-guest-only">Login</a>
+        <a href="auth.html" class="btn-primary auth-guest-only">Sign Up</a>
+
+        <a href="my_profile.html" class="btn-primary auth-loggedin-only hidden">Profile</a>
+        <a href="watchlist_page.html" id="watchlist-logout-btn" class="btn-ghost auth-loggedin-only hidden">Logout</a>
       </div>
     </div>
   </nav>
 
-  <main>
-    <section class="page-section watchlist-hero">
-      <div class="page-container watchlist-hero-card card-cinema">
-        <div class="watchlist-intro">
-          <span class="watchlist-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M18 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2zm-6.5 3.5h-3v1h3v3h1v-3h3v-1h-3v-3h-1v3z"/></svg>
-          </span>
-          <div>
-            <p class="eyebrow">Watchlist</p>
-            <h1 class="hero-heading">My Watchlist</h1>
-            <p class="hero-copy">Keep track of the films you want to watch, sort by rating or release year, and jump back into the queue with one click.</p>
+  <main class="watchlist-main">
+    <!-- EMPTY / GUEST WATCHLIST STATE -->
+    <div id="watchlist-empty-state" class="watchlist-state">
+      <section class="page-section watchlist-empty-hero">
+        <div class="page-container">
+          <div class="card-cinema watchlist-empty-card">
+            <span class="empty-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9-4.03-9-9-9zm0 2a7 7 0 110 14 7 7 0 010-14zm1 3h-2v5h5v-2h-3V8z"/>
+              </svg>
+            </span>
+            <h1 id="watchlist-empty-title" class="hero-heading">Your Watchlist is Empty</h1>
+            <p id="watchlist-empty-copy" class="hero-copy">
+              Start building your watchlist by browsing movies and adding the ones you want to watch later.
+            </p>
+            <div class="card-actions">
+              <a id="watchlist-empty-cta" href="home_page.html" class="btn-primary">Browse Movies</a>
+            </div>
           </div>
         </div>
-        <div class="card-actions">
-          <a href="#" class="btn-nav">Add more titles</a>
-          <a href="#" class="btn-nav">Open recommendations</a>
+      </section>
+
+      <section id="watchlist-empty-info-section" class="page-section">
+        <div class="page-container card-cinema watchlist-empty-info">
+          <h2 class="section-title">How to build your watchlist</h2>
+          <div class="card-content">
+            <ol class="card-meta">
+              <li>Browse movies from our collection on the home page.</li>
+              <li>Click on any movie card for details and reviews.</li>
+              <li>Add movies to your watchlist by clicking the button on the card.</li>
+            </ol>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
 
-    <section class="page-section">
-      <div class="page-container watchlist-sort-card card-cinema">
-        <div class="sort-bar">
-          <div class="sort-label">
-            <span class="eyebrow">Sort by</span>
-          </div>
-          <div class="sort-options">
-            <a href="#" class="btn-filter active">Date Added</a>
-            <a href="#" class="btn-filter">Rating</a>
-            <a href="#" class="btn-filter">Title</a>
-            <a href="#" class="btn-filter">Year</a>
-          </div>
-          <div class="sort-count">3 movies</div>
-        </div>
-      </div>
-    </section>
-
-    <section class="page-section">
-      <div class="page-container watchlist-grid">
-        <article class="card-cinema watchlist-card">
-          <img src="https://images.unsplash.com/photo-1517602302552-471fe67acf66?auto=format&fit=crop&w=900&q=80" alt="Hidden Truth" />
-          <div class="card-badge">★ 8.9</div>
-          <div class="card-content">
-            <h3 class="card-title">Hidden Truth</h3>
-            <div class="card-meta">
-              <span>2025</span>
-              <span>Mystery</span>
-            </div>
-            <div class="card-actions">
-              <a href="#" class="btn-ghost">Remove</a>
+    <!-- FILLED WATCHLIST STATE -->
+    <div id="watchlist-filled-state" class="watchlist-state hidden">
+      <section class="page-section watchlist-hero">
+        <div class="page-container watchlist-hero-card card-cinema">
+          <div class="watchlist-intro">
+            <span class="watchlist-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M18 4H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2zm-6.5 3.5h-3v1h3v3h1v-3h3v-1h-3v-3h-1v3z"/>
+              </svg>
+            </span>
+            <div>
+              <p class="eyebrow">Watchlist</p>
+              <h1 class="hero-heading">My Watchlist</h1>
+              <p class="hero-copy">
+                Keep track of the films you want to watch, sort by rating or release year, and jump back
+                into the queue with one click.
+              </p>
             </div>
           </div>
-        </article>
-
-        <article class="card-cinema watchlist-card">
-          <img src="https://images.unsplash.com/photo-1517602302552-471fe67acf66?auto=format&fit=crop&w=900&q=80" alt="Flight of Rebels" />
-          <div class="card-badge">★ 8.5</div>
-          <div class="card-content">
-            <h3 class="card-title">Flight of Rebels</h3>
-            <div class="card-meta">
-              <span>2024</span>
-              <span>Action</span>
-            </div>
-            <div class="card-actions">
-              <a href="#" class="btn-ghost">Remove</a>
-            </div>
-          </div>
-        </article>
-
-        <article class="card-cinema watchlist-card">
-          <img src="https://images.unsplash.com/photo-1505685296765-3a2736de412f?auto=format&fit=crop&w=900&q=80" alt="Nightfall" />
-          <div class="card-badge">★ 8.6</div>
-          <div class="card-content">
-            <h3 class="card-title">Nightfall</h3>
-            <div class="card-meta">
-              <span>2023</span>
-              <span>Drama</span>
-            </div>
-            <div class="card-actions">
-              <a href="#" class="btn-ghost">Remove</a>
-            </div>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <section class="page-section">
-      <div class="page-container card-cinema">
-        <div class="card-content">
-          <h2 class="section-title">Need viewing inspiration?</h2>
-          <p class="hero-copy">Keep your watchlist full with curated movie picks and reminders for the next great watch night.</p>
           <div class="card-actions">
-            <a href="#" class="btn-primary">Browse recommendations</a>
+            <a href="#" class="btn-nav">Add more titles</a>
+            <a href="#" class="btn-nav">Open recommendations</a>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      <section class="page-section">
+        <div class="page-container watchlist-sort-card card-cinema">
+          <div class="sort-bar">
+            <div class="sort-label">
+              <span class="eyebrow">Sort by</span>
+            </div>
+            <div class="sort-options">
+              <a href="#" class="btn-filter active">Date Added</a>
+              <a href="#" class="btn-filter">Rating</a>
+              <a href="#" class="btn-filter">Title</a>
+              <a href="#" class="btn-filter">Year</a>
+            </div>
+            <div class="sort-count">3 movies</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="page-section">
+        <div class="page-container watchlist-grid">
+          <article class="card-cinema watchlist-card">
+            <img src="https://images.unsplash.com/photo-1517602302552-471fe67acf66?auto=format&fit=crop&w=900&q=80" alt="Hidden Truth" />
+            <div class="card-badge">★ 8.9</div>
+            <div class="card-content">
+              <h3 class="card-title">Hidden Truth</h3>
+              <div class="card-meta">
+                <span>2025</span>
+                <span>Mystery</span>
+              </div>
+              <div class="card-actions">
+                <a href="#" class="btn-ghost">Remove</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="card-cinema watchlist-card">
+            <img src="https://images.unsplash.com/photo-1517602302552-471fe67acf66?auto=format&fit=crop&w=900&q=80" alt="Flight of Rebels" />
+            <div class="card-badge">★ 8.5</div>
+            <div class="card-content">
+              <h3 class="card-title">Flight of Rebels</h3>
+              <div class="card-meta">
+                <span>2024</span>
+                <span>Action</span>
+              </div>
+              <div class="card-actions">
+                <a href="#" class="btn-ghost">Remove</a>
+              </div>
+            </div>
+          </article>
+
+          <article class="card-cinema watchlist-card">
+            <img src="https://images.unsplash.com/photo-1505685296765-3a2736de412f?auto=format&fit=crop&w=900&q=80" alt="Nightfall" />
+            <div class="card-badge">★ 8.6</div>
+            <div class="card-content">
+              <h3 class="card-title">Nightfall</h3>
+              <div class="card-meta">
+                <span>2023</span>
+                <span>Drama</span>
+              </div>
+              <div class="card-actions">
+                <a href="#" class="btn-ghost">Remove</a>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="page-section">
+        <div class="page-container card-cinema">
+          <div class="card-content">
+            <h2 class="section-title">Need viewing inspiration?</h2>
+            <p class="hero-copy">Keep your watchlist full with curated movie picks and reminders for the next great watch night.</p>
+            <div class="card-actions">
+              <a href="#" class="btn-primary">Browse recommendations</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
   </main>
 
   <footer>
     <div class="page-container footer-note">© 2026 Movie Star. Movie nights start here.</div>
   </footer>
+
+  <!-- Demo State Switcher -->
+  <div id="demo-state-switcher" class="demo-state-panel">
+    <button id="demo-toggle-btn" class="demo-toggle-btn" type="button" title="Toggle demo state controls">⚙️</button>
+    <div id="demo-controls" class="demo-controls hidden">
+      <div class="demo-control-group">
+        <label class="demo-label" for="auth-state-select">Auth State</label>
+        <select id="auth-state-select" class="demo-select">
+          <option value="guest">Guest</option>
+          <option value="logged-in">Logged In</option>
+        </select>
+      </div>
+      <div class="demo-control-group">
+        <label class="demo-label" for="watchlist-state-select">Watchlist State</label>
+        <select id="watchlist-state-select" class="demo-select">
+          <option value="empty">Empty</option>
+          <option value="filled">Filled</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <script src="../static/js/watchlist_page.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR refactors the home page and watchlist page to reduce duplicate prototype pages and make the local static preview flow cleaner and more maintainable.

## What changed
- kept `home_page.html` as the canonical home page
- kept `watchlist_page.html` as the canonical watchlist page
- replaced separate state pages with temporary JavaScript-based state handling
- added/updated localStorage demo state for:
  - `movieStarDemoAuth`
  - `movieStarDemoWatchlist`
- made navbar state switch between guest and logged-in
- made guest Login and Sign Up buttons link to `auth.html`
- merged watchlist empty/filled behavior into one page
- kept Tailwind + `style.css` + page-specific CSS structure
- kept all pages working in local static preview mode

## Why this change was needed
Previously, the prototype used multiple separate HTML pages for different user states, which created duplication and made navigation harder to manage.

This PR moves the project toward a cleaner structure while backend/Flask logic is not implemented yet.

## Scope
Main files updated:
- `frontend/templates/home_page.html`
- `frontend/templates/watchlist_page.html`
- `frontend/static/js/home_page.js`
- `frontend/static/js/watchlist_page.js`

Supporting CSS may also have been adjusted where needed for layout consistency.

## Notes
- this PR is still prototype-only and does not use Flask/Jinja yet
- state is temporarily simulated using JavaScript and localStorage
- later, this logic can be replaced by Flask session + Jinja conditionals
- old duplicate pages are now legacy and should no longer be used in navigation

## Related issue
Closes #21 
## Review focus
Please check:
- home page guest/logged-in state switching
- watchlist page empty/filled state switching
- navbar consistency between pages
- guest button links to auth page
- overall structure and maintainability