### PR TITLE
Modules: Likes, Comments, and Profile endpoints

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -10,6 +10,7 @@ Currently contains:
     - SignupForm    (Module A - Auth)
     - SearchForm    (Module B - Movies + Search)
     - ReviewForm    (Module C - Reviews)
+    - CommentForm   (Module C - Comments on reviews)
 """
 from flask_wtf import FlaskForm
 from wtforms import (
@@ -183,3 +184,27 @@ class ReviewForm(FlaskForm):
         ],
     )
     contains_spoilers = BooleanField("Contains spoilers")
+
+
+# Comment form is shared by both POST /review/<id>/comment and
+# POST /comment/<id>/reply — same payload shape (body only), only the
+# route differs.
+
+COMMENT_BODY_MAX = 1000
+
+
+class CommentForm(FlaskForm):
+    """Create a comment on a review or a reply to an existing comment."""
+
+    body = TextAreaField(
+        "Comment",
+        filters=[lambda v: v.strip() if isinstance(v, str) else v],
+        validators=[
+            DataRequired(message="Please write a comment."),
+            Length(
+                min=1,
+                max=COMMENT_BODY_MAX,
+                message=f"Comment must be {COMMENT_BODY_MAX} characters or fewer.",
+            ),
+        ],
+    )

--- a/app/forms.py
+++ b/app/forms.py
@@ -6,11 +6,12 @@ schemas: they validate inputs, render CSRF tokens, and integrate with the
 Flask request lifecycle.
 
 Currently contains:
-    - LoginForm     (Module A - Auth)
-    - SignupForm    (Module A - Auth)
-    - SearchForm    (Module B - Movies + Search)
-    - ReviewForm    (Module C - Reviews)
-    - CommentForm   (Module C - Comments on reviews)
+    - LoginForm        (Module A - Auth)
+    - SignupForm       (Module A - Auth)
+    - SearchForm       (Module B - Movies + Search)
+    - ReviewForm       (Module C - Reviews)
+    - CommentForm      (Module C - Comments on reviews)
+    - ProfileEditForm  (Module E - Profile)
 """
 from flask_wtf import FlaskForm
 from wtforms import (
@@ -208,3 +209,55 @@ class CommentForm(FlaskForm):
             ),
         ],
     )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Module E — Profile edit form
+# ─────────────────────────────────────────────────────────────────────
+
+PROFILE_BIO_MAX = 500
+PROFILE_AVATAR_MAX = 255
+
+
+class ProfileEditForm(FlaskForm):
+    """Edit the current user's profile (username, bio, avatar URL).
+
+    Username uniqueness is checked at the route level because we need
+    access to the database session and the current user's id.
+    """
+
+    username = StringField(
+        "Username",
+        filters=[lambda v: v.strip() if isinstance(v, str) else v],
+        validators=[
+            DataRequired(message="Username is required."),
+            Length(
+                min=3,
+                max=64,
+                message="Username must be between 3 and 64 characters.",
+            ),
+        ],
+    )
+    bio = TextAreaField(
+        "Bio",
+        filters=[lambda v: v.strip() if isinstance(v, str) else v],
+        validators=[
+            Optional(),
+            Length(
+                max=PROFILE_BIO_MAX,
+                message=f"Bio must be {PROFILE_BIO_MAX} characters or fewer.",
+            ),
+        ],
+    )
+    avatar_path = StringField(
+        "Avatar URL",
+        filters=[lambda v: v.strip() if isinstance(v, str) else v],
+        validators=[
+            Optional(),
+            Length(
+                max=PROFILE_AVATAR_MAX,
+                message="Avatar URL is too long.",
+            ),
+        ],
+    )
+    submit = SubmitField("Save changes")

--- a/app/routes.py
+++ b/app/routes.py
@@ -25,8 +25,15 @@ from flask_login import current_user, login_required
 from sqlalchemy import func
 
 from app import app, db
-from app.forms import ReviewForm, SearchForm
-from app.models import Genre, Movie, Review, ReviewLike, WatchlistItem
+from app.forms import CommentForm, ReviewForm, SearchForm
+from app.models import (
+    Genre,
+    Movie,
+    Review,
+    ReviewComment,
+    ReviewLike,
+    WatchlistItem,
+)
 
 
 # Display constants — adjust here if the design tweaks them.
@@ -220,6 +227,7 @@ def movie(movie_id):
 
     reviews = others_query.all()
     review_form = ReviewForm()
+    comment_form = CommentForm()
 
     return render_template(
         "movie_page.html",
@@ -227,6 +235,7 @@ def movie(movie_id):
         reviews=reviews,
         user_review=user_review,
         review_form=review_form,
+        comment_form=comment_form,
         community_count=len(reviews),
         active_sort=sort,
     )
@@ -477,6 +486,92 @@ def review_unlike(review_id):
     db.session.delete(like)
     db.session.commit()
     return jsonify(ok=True, unliked=True, like_count=review.like_count)
+
+
+def _comment_to_json(comment):
+    """Shape a ReviewComment for JSON responses."""
+    return {
+        "id": comment.id,
+        "review_id": comment.review_id,
+        "user_id": comment.user_id,
+        "username": comment.user.username if comment.user else None,
+        "parent_comment_id": comment.parent_comment_id,
+        "body": comment.display_body,
+        "is_deleted": comment.is_deleted,
+        "created_at": comment.created_at.isoformat() if comment.created_at else None,
+    }
+
+
+@app.route("/review/<int:review_id>/comment", methods=["POST"])
+@login_required
+def comment_create(review_id):
+    """Add a top-level comment on a review."""
+    review = db.session.get(Review, review_id)
+    if review is None:
+        return jsonify(ok=False, error="Review not found."), 404
+
+    form = CommentForm()
+    if not form.validate_on_submit():
+        return (
+            jsonify(ok=False, error=_first_form_error(form), errors=form.errors),
+            400,
+        )
+
+    comment = ReviewComment(
+        review_id=review_id,
+        user_id=current_user.id,
+        body=form.body.data,
+        parent_comment_id=None,
+    )
+    db.session.add(comment)
+    db.session.commit()
+    return jsonify(ok=True, comment=_comment_to_json(comment)), 201
+
+
+@app.route("/comment/<int:comment_id>/reply", methods=["POST"])
+@login_required
+def comment_reply(comment_id):
+    """Reply to an existing comment (threaded via parent_comment_id)."""
+    parent = db.session.get(ReviewComment, comment_id)
+    if parent is None:
+        return jsonify(ok=False, error="Comment not found."), 404
+
+    form = CommentForm()
+    if not form.validate_on_submit():
+        return (
+            jsonify(ok=False, error=_first_form_error(form), errors=form.errors),
+            400,
+        )
+
+    reply = ReviewComment(
+        review_id=parent.review_id,
+        user_id=current_user.id,
+        body=form.body.data,
+        parent_comment_id=parent.id,
+    )
+    db.session.add(reply)
+    db.session.commit()
+    return jsonify(ok=True, comment=_comment_to_json(reply)), 201
+
+
+@app.route("/comment/<int:comment_id>/delete", methods=["POST"])
+@login_required
+def comment_delete(comment_id):
+    """Soft-delete one of the current user's own comments.
+
+    We don't hard-delete because the row may be a parent of replies; the
+    template renders display_body which substitutes '[comment removed]'
+    for soft-deleted comments so the thread structure stays intact.
+    """
+    comment = db.session.get(ReviewComment, comment_id)
+    if comment is None:
+        return jsonify(ok=False, error="Comment not found."), 404
+    if comment.user_id != current_user.id:
+        abort(403)
+
+    comment.is_deleted = True
+    db.session.commit()
+    return jsonify(ok=True, deleted=True)
 
 
 @app.route("/review/<int:review_id>/delete", methods=["POST"])

--- a/app/routes.py
+++ b/app/routes.py
@@ -20,18 +20,22 @@ Notes for teammates:
       module. The write-review form and community reviews list belong
       to Module C.
 """
-from flask import abort, jsonify, render_template, request
+from collections import Counter
+
+from flask import abort, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from sqlalchemy import func
 
 from app import app, db
-from app.forms import CommentForm, ReviewForm, SearchForm
+from app.forms import CommentForm, ProfileEditForm, ReviewForm, SearchForm
 from app.models import (
+    Follow,
     Genre,
     Movie,
     Review,
     ReviewComment,
     ReviewLike,
+    User,
     WatchlistItem,
 )
 
@@ -591,16 +595,163 @@ def review_delete(review_id):
 
 
 # ─────────────────────────────────────────────────────────────────────────
-# Pages owned by other modules — kept as thin shells until they take over.
-# Private routes are protected with @login_required (Module A).
+# Module E — Profile + Follow
 # ─────────────────────────────────────────────────────────────────────────
+
+
+def _top_genres_for(user, limit=4):
+    """Compute the user's favourite genres by counting genre tags across
+    all the movies they've reviewed. Returns a list of (name, count)."""
+    counter = Counter()
+    for review in user.reviews:
+        if review.movie is None:
+            continue
+        for g in review.movie.genres:
+            counter[g.name] += 1
+    return counter.most_common(limit)
+
 
 @app.route("/profile")
 @login_required
 def profile():
-    return render_template("my_profile.html")
+    """Render the current user's own profile page."""
+    user = current_user
+    reviews = (
+        Review.query.filter_by(user_id=user.id)
+        .order_by(Review.created_at.desc())
+        .all()
+    )
+    watchlist_count = WatchlistItem.query.filter_by(user_id=user.id).count()
+    liked_count = (
+        ReviewLike.query.filter_by(user_id=user.id).count()
+    )
+    return render_template(
+        "my_profile.html",
+        user=user,
+        reviews=reviews,
+        watchlist_count=watchlist_count,
+        liked_count=liked_count,
+        favourite_genres=_top_genres_for(user),
+    )
 
 
 @app.route("/user/<int:user_id>")
 def user_profile(user_id):
-    return render_template("other_profile.html")
+    """Public profile page for any user.
+
+    If a logged-in user lands on their own /user/<id> URL we redirect to
+    /profile so the 'edit your profile' affordances show up correctly.
+    """
+    user = db.session.get(User, user_id)
+    if user is None:
+        abort(404)
+    if current_user.is_authenticated and current_user.id == user.id:
+        return redirect(url_for("profile"))
+
+    reviews = (
+        Review.query.filter_by(user_id=user.id)
+        .order_by(Review.created_at.desc())
+        .all()
+    )
+    is_following = (
+        current_user.is_authenticated and current_user.is_following(user)
+    )
+    return render_template(
+        "other_profile.html",
+        user=user,
+        reviews=reviews,
+        is_following=is_following,
+    )
+
+
+@app.route("/profile/edit", methods=["GET", "POST"])
+@login_required
+def profile_edit():
+    """Edit the current user's profile.
+
+    GET renders the form pre-filled with existing values; POST validates
+    and persists. Username uniqueness is checked here because it depends
+    on DB state we don't want to bake into the form class.
+    """
+    form = ProfileEditForm()
+
+    if request.method == "GET":
+        form.username.data = current_user.username
+        form.bio.data = current_user.bio or ""
+        form.avatar_path.data = current_user.avatar_path or ""
+        return render_template("profile_edit.html", form=form)
+
+    # POST
+    if not form.validate_on_submit():
+        return (
+            render_template("profile_edit.html", form=form),
+            400,
+        )
+
+    new_username = form.username.data
+    if new_username != current_user.username:
+        clash = db.session.scalar(
+            db.select(User).where(User.username == new_username)
+        )
+        if clash is not None:
+            form.username.errors.append("That username is already taken.")
+            return render_template("profile_edit.html", form=form), 409
+
+    current_user.username = new_username
+    current_user.bio = form.bio.data or None
+    current_user.avatar_path = form.avatar_path.data or None
+    db.session.commit()
+    flash("Profile updated.", "success")
+    return redirect(url_for("profile"))
+
+
+@app.route("/user/<int:user_id>/follow", methods=["POST"])
+@login_required
+def user_follow(user_id):
+    """Follow another user. Idempotent."""
+    target = db.session.get(User, user_id)
+    if target is None:
+        return jsonify(ok=False, error="User not found."), 404
+    if target.id == current_user.id:
+        return jsonify(ok=False, error="You cannot follow yourself."), 400
+
+    if current_user.is_following(target):
+        return jsonify(
+            ok=True,
+            already_following=True,
+            follower_count=target.follower_count,
+        )
+
+    current_user.follow(target)
+    db.session.commit()
+    return (
+        jsonify(
+            ok=True,
+            following=True,
+            follower_count=target.follower_count,
+        ),
+        201,
+    )
+
+
+@app.route("/user/<int:user_id>/unfollow", methods=["POST"])
+@login_required
+def user_unfollow(user_id):
+    """Stop following another user."""
+    target = db.session.get(User, user_id)
+    if target is None:
+        return jsonify(ok=False, error="User not found."), 404
+
+    if not current_user.is_following(target):
+        return (
+            jsonify(ok=False, error="You are not following this user."),
+            404,
+        )
+
+    current_user.unfollow(target)
+    db.session.commit()
+    return jsonify(
+        ok=True,
+        unfollowed=True,
+        follower_count=target.follower_count,
+    )

--- a/app/routes.py
+++ b/app/routes.py
@@ -540,6 +540,18 @@ def comment_reply(comment_id):
     if parent is None:
         return jsonify(ok=False, error="Comment not found."), 404
 
+    # The template renders at most two visual levels (top-level comment
+    # + one row of replies). Reject attempts to reply to a reply so the
+    # DB never accumulates rows the UI cannot show.
+    if parent.parent_comment_id is not None:
+        return (
+            jsonify(
+                ok=False,
+                error="Replies can only be posted on top-level comments.",
+            ),
+            400,
+        )
+
     form = CommentForm()
     if not form.validate_on_submit():
         return (

--- a/app/routes.py
+++ b/app/routes.py
@@ -26,7 +26,7 @@ from sqlalchemy import func
 
 from app import app, db
 from app.forms import ReviewForm, SearchForm
-from app.models import Genre, Movie, Review, WatchlistItem
+from app.models import Genre, Movie, Review, ReviewLike, WatchlistItem
 
 
 # Display constants — adjust here if the design tweaks them.
@@ -431,6 +431,52 @@ def review_edit(review_id):
     # updated_at is filled automatically by the model's onupdate hook.
     db.session.commit()
     return jsonify(ok=True, review=_review_to_json(review))
+
+
+@app.route("/review/<int:review_id>/like", methods=["POST"])
+@login_required
+def review_like(review_id):
+    """Like a review on behalf of the current user.
+
+    Idempotent: re-liking returns 200 with already_liked=True rather than
+    blowing up on the UniqueConstraint(user_id, review_id) of ReviewLike.
+    A user is allowed to like their own review (no self-vote restriction).
+    """
+    review = db.session.get(Review, review_id)
+    if review is None:
+        return jsonify(ok=False, error="Review not found."), 404
+
+    existing = ReviewLike.query.filter_by(
+        user_id=current_user.id, review_id=review_id
+    ).first()
+    if existing is not None:
+        return jsonify(
+            ok=True, already_liked=True, like_count=review.like_count
+        )
+
+    like = ReviewLike(user_id=current_user.id, review_id=review_id)
+    db.session.add(like)
+    db.session.commit()
+    return jsonify(ok=True, liked=True, like_count=review.like_count), 201
+
+
+@app.route("/review/<int:review_id>/unlike", methods=["POST"])
+@login_required
+def review_unlike(review_id):
+    """Remove the current user's like on a review."""
+    review = db.session.get(Review, review_id)
+    if review is None:
+        return jsonify(ok=False, error="Review not found."), 404
+
+    like = ReviewLike.query.filter_by(
+        user_id=current_user.id, review_id=review_id
+    ).first()
+    if like is None:
+        return jsonify(ok=False, error="You have not liked this review."), 404
+
+    db.session.delete(like)
+    db.session.commit()
+    return jsonify(ok=True, unliked=True, like_count=review.like_count)
 
 
 @app.route("/review/<int:review_id>/delete", methods=["POST"])

--- a/app/static/js/movie_page.js
+++ b/app/static/js/movie_page.js
@@ -23,6 +23,7 @@ const deleteButtons = Array.from(document.querySelectorAll('.review-delete-btn')
 const editCancelButtons = Array.from(document.querySelectorAll('.review-edit-cancel'));
 const editForms = Array.from(document.querySelectorAll('.review-edit-form'));
 const reviewSortSelect = document.getElementById('review-sort-select');
+const likeButtons = Array.from(document.querySelectorAll('.review-like-btn'));
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -186,6 +187,38 @@ editForms.forEach((form) => {
 
     if (submitBtn) submitBtn.disabled = false;
     showError(result.data && result.data.error);
+  });
+});
+
+// ── Like / unlike a review ────────────────────────────────────────
+
+likeButtons.forEach((btn) => {
+  btn.addEventListener('click', async () => {
+    const reviewId = btn.dataset.reviewId;
+    if (!reviewId) return;
+
+    const isLiked = btn.classList.contains('is-liked');
+    const action = isLiked ? 'unlike' : 'like';
+
+    btn.disabled = true;
+    const result = await postJson(`/review/${reviewId}/${action}`);
+    if (result === null) return;
+
+    if (result.ok) {
+      // Flip the visual state and update the count from the server's
+      // authoritative response, then re-enable the button.
+      btn.classList.toggle('is-liked');
+      const textSpan = btn.querySelector('.review-like-text');
+      const countSpan = btn.querySelector('.review-like-count');
+      if (textSpan) textSpan.textContent = isLiked ? 'Like' : 'Liked';
+      if (countSpan && typeof result.data.like_count === 'number') {
+        countSpan.textContent = `(${result.data.like_count})`;
+      }
+      btn.disabled = false;
+    } else {
+      btn.disabled = false;
+      showError(result.data && result.data.error);
+    }
   });
 });
 

--- a/app/static/js/movie_page.js
+++ b/app/static/js/movie_page.js
@@ -24,6 +24,11 @@ const editCancelButtons = Array.from(document.querySelectorAll('.review-edit-can
 const editForms = Array.from(document.querySelectorAll('.review-edit-form'));
 const reviewSortSelect = document.getElementById('review-sort-select');
 const likeButtons = Array.from(document.querySelectorAll('.review-like-btn'));
+const commentForms = Array.from(document.querySelectorAll('.comment-form'));
+const replyForms = Array.from(document.querySelectorAll('.comment-reply-form'));
+const replyButtons = Array.from(document.querySelectorAll('.comment-reply-btn'));
+const replyCancelButtons = Array.from(document.querySelectorAll('.comment-reply-cancel'));
+const commentDeleteButtons = Array.from(document.querySelectorAll('.comment-delete-btn'));
 
 // ── Helpers ────────────────────────────────────────────────────────
 
@@ -186,6 +191,79 @@ editForms.forEach((form) => {
     }
 
     if (submitBtn) submitBtn.disabled = false;
+    showError(result.data && result.data.error);
+  });
+});
+
+// ── Comments: post / reply / delete ────────────────────────────────
+//
+// All three flows submit FormData with the X-CSRFToken header through
+// the shared postJson helper and reload the page on success, so the
+// re-rendered server template is the source of truth for thread order
+// and counts.
+
+function getCommentReplyForm(commentId) {
+  return document.querySelector(`.comment-reply-form[data-comment-id="${commentId}"]`);
+}
+
+replyButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const form = getCommentReplyForm(btn.dataset.commentId);
+    if (form) form.classList.remove('hidden');
+  });
+});
+
+replyCancelButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const form = getCommentReplyForm(btn.dataset.commentId);
+    if (form) {
+      form.classList.add('hidden');
+      const ta = form.querySelector('textarea');
+      if (ta) ta.value = '';
+    }
+  });
+});
+
+function bindCommentForm(form) {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const submitBtn = form.querySelector('button[type="submit"]');
+    if (submitBtn) submitBtn.disabled = true;
+
+    const result = await postJson(form.action, { body: new FormData(form) });
+    if (result === null) return;
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (submitBtn) submitBtn.disabled = false;
+    showError(result.data && result.data.error);
+  });
+}
+
+commentForms.forEach(bindCommentForm);
+replyForms.forEach(bindCommentForm);
+
+commentDeleteButtons.forEach((btn) => {
+  btn.addEventListener('click', async () => {
+    const commentId = btn.dataset.commentId;
+    if (!commentId) return;
+
+    const confirmed = window.confirm('Delete this comment? It will be marked as removed in the thread.');
+    if (!confirmed) return;
+
+    btn.disabled = true;
+    const result = await postJson(`/comment/${commentId}/delete`);
+    if (result === null) return;
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    btn.disabled = false;
     showError(result.data && result.data.error);
   });
 });

--- a/app/static/js/my_profile.js
+++ b/app/static/js/my_profile.js
@@ -1,62 +1,15 @@
-const navbar = document.getElementById('navbar');
-const logoutButton = document.getElementById('my-profile-logout-btn');
-const editProfileButton = document.getElementById('edit-profile-btn');
-const editButtons = Array.from(document.querySelectorAll('[data-review-edit]'));
-const deleteButtons = Array.from(document.querySelectorAll('[data-review-delete]'));
-const loggedInNavLinks = Array.from(document.querySelectorAll('[data-auth-nav="logged-in"]'));
+// My profile page interactions.
+//
+// All the demo localStorage / fake-auth logic that used to live here has
+// been removed now that the page is server-rendered with real data and
+// gated behind @login_required. The Edit Profile button is a plain link
+// to /profile/edit so no JS is required for it either; this file just
+// keeps the navbar scroll effect for visual polish.
 
-const preserveLoggedInState = () => {
-  try {
-    localStorage.setItem('movieStarDemoAuth', 'logged-in');
-  } catch (error) {
-    // Ignore storage failures in static preview.
-  }
-};
+const navbar = document.getElementById('navbar');
 
 if (navbar) {
   window.addEventListener('scroll', () => {
     navbar.classList.toggle('scrolled', window.scrollY > 40);
   });
 }
-
-if (logoutButton) {
-  logoutButton.addEventListener('click', () => {
-    try {
-      localStorage.setItem('movieStarDemoAuth', 'guest');
-    } catch (error) {
-      // Ignore storage failures in static preview.
-    }
-  });
-}
-
-loggedInNavLinks.forEach((link) => {
-  link.addEventListener('click', preserveLoggedInState);
-});
-
-if (editProfileButton) {
-  editProfileButton.addEventListener('click', () => {
-    window.alert('Edit profile is not implemented in this prototype yet.');
-  });
-}
-
-editButtons.forEach((button) => {
-  button.addEventListener('click', () => {
-    window.alert('Review editing is postponed in this simplified prototype.');
-  });
-});
-
-deleteButtons.forEach((button) => {
-  button.addEventListener('click', () => {
-    const reviewCard = button.closest('[data-review-card]');
-
-    if (!reviewCard) {
-      return;
-    }
-
-    const confirmed = window.confirm('Remove this review from the profile list?');
-
-    if (confirmed) {
-      reviewCard.remove();
-    }
-  });
-});

--- a/app/static/js/other_profile.js
+++ b/app/static/js/other_profile.js
@@ -1,19 +1,50 @@
+// Other user's profile page interactions.
+//
+// Two things this file does:
+//   * Navbar scroll effect for visual polish.
+//   * Follow / Unfollow toggle on the hero card, posting to
+//     /user/<id>/follow or /unfollow and updating the visible follower
+//     count from the server's authoritative response.
+//
+// CSRF: token is read from <meta name="csrf-token"> in the page head.
+
 const navbar = document.getElementById('navbar');
-const logoutButton = document.getElementById('other-profile-logout-btn');
 const followButton = document.getElementById('follow-btn');
-const followerCount = document.getElementById('follower-count');
-const likeButtons = Array.from(document.querySelectorAll('[data-like-btn]'));
-const loggedInNavLinks = Array.from(document.querySelectorAll('[data-auth-nav="logged-in"]'));
+const followerCountEl = document.getElementById('follower-count');
 
-let isFollowing = false;
+// ── Helpers ────────────────────────────────────────────────────────
 
-const preserveLoggedInState = () => {
-  try {
-    localStorage.setItem('movieStarDemoAuth', 'logged-in');
-  } catch (error) {
-    // Ignore storage failures in static preview.
+function getCsrfToken() {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta ? meta.content : '';
+}
+
+async function postFollow(action, userId) {
+  // action is 'follow' or 'unfollow'.
+  const response = await fetch(`/user/${userId}/${action}`, {
+    method: 'POST',
+    headers: {
+      'X-CSRFToken': getCsrfToken(),
+      'Accept': 'application/json',
+    },
+  });
+
+  if (response.redirected || response.status === 401) {
+    const next = encodeURIComponent(window.location.pathname);
+    window.location.href = `/auth?next=${next}`;
+    return null;
   }
-};
+
+  let data = {};
+  try {
+    data = await response.json();
+  } catch (e) {
+    // Not JSON.
+  }
+  return { ok: response.ok, status: response.status, data };
+}
+
+// ── Navbar ────────────────────────────────────────────────────────
 
 if (navbar) {
   window.addEventListener('scroll', () => {
@@ -21,42 +52,35 @@ if (navbar) {
   });
 }
 
-if (logoutButton) {
-  logoutButton.addEventListener('click', () => {
-    try {
-      localStorage.setItem('movieStarDemoAuth', 'guest');
-    } catch (error) {
-      // Ignore storage failures in static preview.
+// ── Follow / Unfollow ──────────────────────────────────────────────
+
+if (followButton) {
+  followButton.addEventListener('click', async () => {
+    const userId = followButton.dataset.userId;
+    if (!userId) return;
+
+    const isFollowing = followButton.classList.contains('is-following');
+    const action = isFollowing ? 'unfollow' : 'follow';
+
+    followButton.disabled = true;
+    const result = await postFollow(action, userId);
+    if (result === null) return;
+
+    if (result.ok) {
+      followButton.classList.toggle('is-following');
+      followButton.textContent = isFollowing ? 'Follow' : 'Following';
+      if (
+        followerCountEl
+        && typeof result.data.follower_count === 'number'
+      ) {
+        followerCountEl.textContent = result.data.follower_count;
+      }
+      followButton.disabled = false;
+    } else {
+      followButton.disabled = false;
+      const message = (result.data && result.data.error)
+        || 'Could not update your follow status.';
+      window.alert(message);
     }
   });
 }
-
-loggedInNavLinks.forEach((link) => {
-  link.addEventListener('click', preserveLoggedInState);
-});
-
-if (followButton && followerCount) {
-  followButton.addEventListener('click', () => {
-    const currentFollowers = Number(followerCount.textContent);
-
-    isFollowing = !isFollowing;
-    followerCount.textContent = String(isFollowing ? currentFollowers + 1 : currentFollowers - 1);
-    followButton.textContent = isFollowing ? 'Following' : 'Follow';
-    followButton.classList.toggle('btn-ghost', isFollowing);
-    followButton.classList.toggle('btn-primary', !isFollowing);
-  });
-}
-
-likeButtons.forEach((button) => {
-  button.addEventListener('click', () => {
-    const count = button.querySelector('.like-count');
-
-    if (!count) {
-      return;
-    }
-
-    const current = Number(count.textContent);
-    const isLiked = button.classList.toggle('is-liked');
-    count.textContent = String(isLiked ? current + 1 : current - 1);
-  });
-});

--- a/app/templates/movie_page.html
+++ b/app/templates/movie_page.html
@@ -153,6 +153,15 @@
                     {% endif %}
                   </p>
                   <div class="review-actions-row review-actions-row-end">
+                    {# Like button — yes, you may like your own review. #}
+                    <button
+                      class="helpful-btn review-like-btn {% if user_review.is_liked_by(current_user) %}is-liked{% endif %}"
+                      type="button"
+                      data-review-id="{{ user_review.id }}"
+                    >
+                      <span class="review-like-text">{% if user_review.is_liked_by(current_user) %}Liked{% else %}Like{% endif %}</span>
+                      <span class="review-like-count">({{ user_review.like_count }})</span>
+                    </button>
                     <button class="btn-ghost review-edit-btn" type="button" data-review-id="{{ user_review.id }}">Edit</button>
                     <button class="btn-ghost review-delete-btn" type="button" data-review-id="{{ user_review.id }}">Delete</button>
                   </div>
@@ -293,6 +302,16 @@
                   <p class="review-spoiler-warning">&#9888; Contains spoilers</p>
                 {% endif %}
                 <p class="review-copy">{{ review.body }}</p>
+                <div class="review-footer-row">
+                  <button
+                    class="helpful-btn review-like-btn {% if review.is_liked_by(current_user) %}is-liked{% endif %}"
+                    type="button"
+                    data-review-id="{{ review.id }}"
+                  >
+                    <span class="review-like-text">{% if review.is_liked_by(current_user) %}Liked{% else %}Like{% endif %}</span>
+                    <span class="review-like-count">({{ review.like_count }})</span>
+                  </button>
+                </div>
               </article>
             {% else %}
               <p class="content-copy">No reviews yet. Be the first to share your thoughts!</p>

--- a/app/templates/movie_page.html
+++ b/app/templates/movie_page.html
@@ -11,6 +11,112 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/movie_page.css') }}" />
 </head>
 <body class="movie-page min-h-screen">
+
+  {#
+    ─── Macros for rendering review comments ───────────────────────────
+    The model supports unbounded nesting via parent_comment_id, but for
+    UI clarity we render at most two levels: top-level comments + their
+    direct replies (flat, no replies-of-replies on the page).
+  #}
+
+  {% macro render_comment_card(comment, is_reply=False) %}
+    <div class="comment-card {% if is_reply %}comment-reply{% endif %} {% if comment.is_deleted %}comment-deleted{% endif %}"
+         data-comment-id="{{ comment.id }}">
+      <div class="comment-meta">
+        {% if comment.user %}
+          <a href="{{ url_for('user_profile', user_id=comment.user_id) }}" class="comment-user-link">
+            {{ comment.user.username }}
+          </a>
+        {% else %}
+          <span class="comment-user-link">[deleted user]</span>
+        {% endif %}
+        <span class="comment-date">{{ comment.created_at.strftime('%b %d, %Y') }}</span>
+      </div>
+
+      <p class="comment-body">{{ comment.display_body }}</p>
+
+      {% if not comment.is_deleted and current_user.is_authenticated %}
+        <div class="comment-actions-row">
+          {% if not is_reply %}
+            <button class="comment-reply-btn" type="button" data-comment-id="{{ comment.id }}">Reply</button>
+          {% endif %}
+          {% if comment.user_id == current_user.id %}
+            <button class="comment-delete-btn" type="button" data-comment-id="{{ comment.id }}">Delete</button>
+          {% endif %}
+        </div>
+
+        {% if not is_reply %}
+          {# Hidden reply form, toggled by JS. #}
+          <form class="comment-reply-form hidden"
+                action="{{ url_for('comment_reply', comment_id=comment.id) }}"
+                method="post"
+                data-comment-id="{{ comment.id }}">
+            {{ comment_form.hidden_tag() }}
+            <textarea name="body" rows="2" maxlength="1000" required
+                      placeholder="Write a reply..."
+                      class="field-input comment-textarea"></textarea>
+            <div class="comment-form-actions">
+              <button type="button" class="btn-ghost comment-reply-cancel" data-comment-id="{{ comment.id }}">Cancel</button>
+              <button type="submit" class="btn-primary">Reply</button>
+            </div>
+          </form>
+        {% endif %}
+      {% endif %}
+    </div>
+  {% endmacro %}
+
+  {% macro render_comments_section(review) %}
+    <section class="review-comments-section">
+      <h4 class="review-comments-title">
+        Comments <span class="review-comments-count">({{ review.comments | rejectattr('is_deleted') | list | length }})</span>
+      </h4>
+
+      <div class="comment-list">
+        {#
+          Iterate over ALL top-level comments (the model's
+          top_level_comments helper filters out is_deleted, which would
+          drop replies-of-deleted-parents from the page). We keep a
+          deleted parent visible if any of its replies are still alive,
+          showing it as the "[comment removed]" placeholder so the
+          thread structure stays readable.
+        #}
+        {% set rendered_any = namespace(value=False) %}
+        {% for top in review.comments if top.parent_comment_id is none %}
+          {% set visible_replies = top.replies | rejectattr('is_deleted') | list %}
+          {% if not top.is_deleted or visible_replies %}
+            {{ render_comment_card(top, is_reply=False) }}
+            {% for reply in visible_replies %}
+              {{ render_comment_card(reply, is_reply=True) }}
+            {% endfor %}
+            {% set rendered_any.value = True %}
+          {% endif %}
+        {% endfor %}
+        {% if not rendered_any.value %}
+          <p class="comment-empty">No comments yet.</p>
+        {% endif %}
+      </div>
+
+      {% if current_user.is_authenticated %}
+        <form class="comment-form"
+              action="{{ url_for('comment_create', review_id=review.id) }}"
+              method="post"
+              data-review-id="{{ review.id }}">
+          {{ comment_form.hidden_tag() }}
+          <textarea name="body" rows="2" maxlength="1000" required
+                    placeholder="Add a comment..."
+                    class="field-input comment-textarea"></textarea>
+          <div class="comment-form-actions">
+            <button type="submit" class="btn-primary">Post comment</button>
+          </div>
+        </form>
+      {% else %}
+        <p class="comment-empty-cta">
+          <a href="{{ url_for('auth') }}" class="text-gold">Log in</a> to leave a comment.
+        </p>
+      {% endif %}
+    </section>
+  {% endmacro %}
+
   <nav class="navbar-cinema" id="navbar">
     <div class="page-container movie-nav-wrap">
       <a href="{{ url_for('home') }}" class="nav-logo">Movie Star</a>
@@ -167,6 +273,8 @@
                   </div>
                 </div>
 
+                {{ render_comments_section(user_review) }}
+
                 {# Inline edit form, hidden until "Edit" is clicked (JS in next commit). #}
                 <form
                   class="write-review-card review-edit-form hidden"
@@ -312,6 +420,8 @@
                     <span class="review-like-count">({{ review.like_count }})</span>
                   </button>
                 </div>
+
+                {{ render_comments_section(review) }}
               </article>
             {% else %}
               <p class="content-copy">No reviews yet. Be the first to share your thoughts!</p>

--- a/app/templates/my_profile.html
+++ b/app/templates/my_profile.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Movie Star | My Profile</title>
+  <title>Movie Star | {{ user.username }}</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/my_profile.css') }}" />
@@ -14,13 +14,18 @@
       <a href="{{ url_for('home') }}" class="nav-logo">Movie Star</a>
 
       <ul class="nav-links">
-        <li><a href="{{ url_for('home') }}" data-auth-nav="logged-in">Home</a></li>
-        <li><a href="{{ url_for('watchlist') }}" data-auth-nav="logged-in">Watchlist</a></li>
+        <li><a href="{{ url_for('home') }}">Home</a></li>
+        <li><a href="{{ url_for('watchlist') }}">Watchlist</a></li>
       </ul>
 
       <div class="nav-actions profile-nav-actions">
-        <a href="{{ url_for('profile') }}" class="btn-primary" data-auth-nav="logged-in">Profile</a>
-        <a href="{{ url_for('logout') }}" id="my-profile-logout-btn" class="btn-ghost">Logout</a>
+        {% if current_user.is_authenticated %}
+          <a href="{{ url_for('profile') }}" class="btn-primary">Profile</a>
+          <a href="{{ url_for('logout') }}" id="my-profile-logout-btn" class="btn-ghost">Logout</a>
+        {% else %}
+          <a href="{{ url_for('auth') }}" class="btn-ghost">Login</a>
+          <a href="{{ url_for('auth') }}" class="btn-primary">Sign Up</a>
+        {% endif %}
       </div>
     </div>
   </nav>
@@ -30,34 +35,44 @@
       <div class="page-container">
         <div class="card-cinema profile-hero-card">
           <div class="profile-avatar-wrap">
-            <img src="https://i.pravatar.cc/120?img=12" alt="Alex Chen avatar" class="profile-avatar" />
+            {% if user.avatar_path %}
+              <img src="{{ user.avatar_path }}" alt="{{ user.username }} avatar" class="profile-avatar" />
+            {% else %}
+              <img src="https://i.pravatar.cc/120?u={{ user.id }}" alt="{{ user.username }} avatar" class="profile-avatar" />
+            {% endif %}
           </div>
 
           <div class="profile-hero-copy">
             <p class="eyebrow">My Profile</p>
-            <h1 class="profile-name">Alex Chen</h1>
-            <p class="profile-meta">@alex_chen / Joined March 2024</p>
-            <p class="profile-bio">
-              Film lover, sci-fi obsessive, and regular review poster. Usually watching something thoughtful,
-              strange, or visually ambitious.
+            <h1 class="profile-name">{{ user.username }}</h1>
+            <p class="profile-meta">
+              @{{ user.username }}
+              {% if user.created_at %}
+                &middot; Joined {{ user.created_at.strftime('%B %Y') }}
+              {% endif %}
             </p>
+            {% if user.bio %}
+              <p class="profile-bio">{{ user.bio }}</p>
+            {% else %}
+              <p class="profile-bio profile-bio-muted">Tell other film lovers what you watch.</p>
+            {% endif %}
           </div>
 
           <div class="profile-hero-actions">
-            <button id="edit-profile-btn" class="btn-nav" type="button">Edit Profile</button>
+            <a href="{{ url_for('profile_edit') }}" id="edit-profile-btn" class="btn-nav">Edit Profile</a>
           </div>
 
           <div class="profile-stats">
             <div class="profile-stat">
-              <span class="profile-stat-value">28</span>
+              <span class="profile-stat-value">{{ user.review_count }}</span>
               <span class="profile-stat-label">Reviews</span>
             </div>
             <div class="profile-stat">
-              <span class="profile-stat-value">143</span>
+              <span class="profile-stat-value">{{ user.following_count }}</span>
               <span class="profile-stat-label">Following</span>
             </div>
             <div class="profile-stat">
-              <span class="profile-stat-value">381</span>
+              <span class="profile-stat-value">{{ user.follower_count }}</span>
               <span class="profile-stat-label">Followers</span>
             </div>
           </div>
@@ -73,96 +88,53 @@
               <p class="eyebrow">Recent Activity</p>
               <h2 class="section-title">My Reviews</h2>
             </div>
-            <p class="section-copy">A short list of recent reviews from this prototype profile.</p>
+            <p class="section-copy">
+              {% if reviews %}
+                Showing {{ reviews | length }} review{{ 's' if reviews | length != 1 else '' }}.
+              {% else %}
+                No reviews yet — head to a <a href="{{ url_for('home') }}" class="text-gold">movie page</a> to write your first one.
+              {% endif %}
+            </p>
           </div>
 
           <div class="profile-review-list">
-            <article class="card-cinema profile-review-card" data-review-card>
-              <div class="profile-review-poster-wrap">
-                <img src="https://image.tmdb.org/t/p/w92/AmR3JG1VQVxU8TfAvljUhfSFUOx.jpg" alt="Dune: Part Two poster" class="profile-review-poster" />
-              </div>
-              <div class="profile-review-body">
-                <div class="profile-review-top">
-                  <div>
-                    <h3 class="profile-review-title">Dune: Part Two</h3>
-                    <p class="profile-review-meta">2024 / Sci-Fi / Denis Villeneuve</p>
+            {% for review in reviews %}
+              {% set movie = review.movie %}
+              <article class="card-cinema profile-review-card" data-review-id="{{ review.id }}">
+                <a href="{{ url_for('movie', movie_id=movie.id) }}" class="profile-review-poster-wrap">
+                  {% if movie.poster_path %}
+                    <img src="{{ movie.poster_path }}" alt="{{ movie.title }} poster" class="profile-review-poster" />
+                  {% else %}
+                    <img src="https://picsum.photos/seed/profile{{ movie.id }}/92/138" alt="{{ movie.title }} poster" class="profile-review-poster" />
+                  {% endif %}
+                </a>
+                <div class="profile-review-body">
+                  <div class="profile-review-top">
+                    <div>
+                      <h3 class="profile-review-title">
+                        <a href="{{ url_for('movie', movie_id=movie.id) }}">{{ movie.title }}</a>
+                      </h3>
+                      <p class="profile-review-meta">
+                        {% if movie.release_year %}{{ movie.release_year }}{% endif %}
+                        {% if movie.primary_genre %} / {{ movie.primary_genre }}{% endif %}
+                        {% if movie.director_name %} / {{ movie.director_name }}{% endif %}
+                      </p>
+                    </div>
+                    <span class="profile-review-rating">&#9733; {{ review.rating }}/10</span>
                   </div>
-                  <span class="profile-review-rating">&#9733; 5/5</span>
-                </div>
-                <p class="profile-review-copy">
-                  Villeneuve delivers scale without losing emotional control. The set pieces land, the pacing stays sharp,
-                  and every image feels like it belongs on a cinema screen.
-                </p>
-                <div class="profile-review-footer">
-                  <div class="profile-review-meta-group">
-                    <span class="profile-review-date">Posted 10 March 2024</span>
-                    <span class="profile-review-likes">24 likes</span>
-                  </div>
-                  <div class="profile-review-actions">
-                    <button class="review-action-btn" type="button" data-review-edit>Edit</button>
-                    <button class="review-action-btn review-action-btn-danger" type="button" data-review-delete>Delete</button>
-                  </div>
-                </div>
-              </div>
-            </article>
-
-            <article class="card-cinema profile-review-card" data-review-card>
-              <div class="profile-review-poster-wrap">
-                <img src="https://image.tmdb.org/t/p/w92/wTnV3PCVW5O92JMrFvvrRcV39RU.jpg" alt="Past Lives poster" class="profile-review-poster" />
-              </div>
-              <div class="profile-review-body">
-                <div class="profile-review-top">
-                  <div>
-                    <h3 class="profile-review-title">Past Lives</h3>
-                    <p class="profile-review-meta">2023 / Romance / Celine Song</p>
-                  </div>
-                  <span class="profile-review-rating">&#9733; 5/5</span>
-                </div>
-                <p class="profile-review-copy">
-                  Quiet, precise, and devastating in the best way. It says a lot with very little and trusts the audience
-                  to sit with the emotional weight.
-                </p>
-                <div class="profile-review-footer">
-                  <div class="profile-review-meta-group">
-                    <span class="profile-review-date">Posted 4 February 2024</span>
-                    <span class="profile-review-likes">31 likes</span>
-                  </div>
-                  <div class="profile-review-actions">
-                    <button class="review-action-btn" type="button" data-review-edit>Edit</button>
-                    <button class="review-action-btn review-action-btn-danger" type="button" data-review-delete>Delete</button>
+                  <p class="profile-review-copy">{{ review.body }}</p>
+                  <div class="profile-review-footer">
+                    <div class="profile-review-meta-group">
+                      <span class="profile-review-date">Posted {{ review.created_at.strftime('%d %B %Y') }}</span>
+                      <span class="profile-review-likes">{{ review.like_count }} like{{ 's' if review.like_count != 1 else '' }}</span>
+                    </div>
+                    <div class="profile-review-actions">
+                      <a href="{{ url_for('movie', movie_id=movie.id) }}#write-review" class="review-action-btn">Open</a>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </article>
-
-            <article class="card-cinema profile-review-card" data-review-card>
-              <div class="profile-review-poster-wrap">
-                <img src="https://image.tmdb.org/t/p/w92/vZloFAK7NmvMGKE7VkF5UHaz0I.jpg" alt="Poor Things poster" class="profile-review-poster" />
-              </div>
-              <div class="profile-review-body">
-                <div class="profile-review-top">
-                  <div>
-                    <h3 class="profile-review-title">Poor Things</h3>
-                    <p class="profile-review-meta">2023 / Drama / Yorgos Lanthimos</p>
-                  </div>
-                  <span class="profile-review-rating">&#9733; 3/5</span>
-                </div>
-                <p class="profile-review-copy">
-                  Bold and visually inventive, but the performance and design work carried me more than the full story did.
-                  Still a memorable watch.
-                </p>
-                <div class="profile-review-footer">
-                  <div class="profile-review-meta-group">
-                    <span class="profile-review-date">Posted 20 January 2024</span>
-                    <span class="profile-review-likes">9 likes</span>
-                  </div>
-                  <div class="profile-review-actions">
-                    <button class="review-action-btn" type="button" data-review-edit>Edit</button>
-                    <button class="review-action-btn review-action-btn-danger" type="button" data-review-delete>Delete</button>
-                  </div>
-                </div>
-              </div>
-            </article>
+              </article>
+            {% endfor %}
           </div>
         </div>
 
@@ -171,11 +143,42 @@
             <p class="eyebrow">Overview</p>
             <h2 class="sidebar-title">Average Rating</h2>
             <div class="sidebar-rating-row">
-              <span class="sidebar-rating-value">4.2</span>
-              <span class="sidebar-rating-total">/ 5</span>
+              {% if user.average_rating is not none %}
+                <span class="sidebar-rating-value">{{ '%.1f' % user.average_rating }}</span>
+                <span class="sidebar-rating-total">/ 10</span>
+              {% else %}
+                <span class="sidebar-rating-value">—</span>
+              {% endif %}
             </div>
-            <p class="sidebar-copy">Based on 28 submitted reviews.</p>
+            <p class="sidebar-copy">
+              {% if user.review_count > 0 %}
+                Based on {{ user.review_count }} submitted review{{ 's' if user.review_count != 1 else '' }}.
+              {% else %}
+                Submit your first review to start a rating average.
+              {% endif %}
+            </p>
           </div>
+
+          <div class="card-cinema profile-side-card">
+            <p class="eyebrow">Library</p>
+            <h2 class="sidebar-title">At a glance</h2>
+            <ul class="profile-side-list">
+              <li><a href="{{ url_for('watchlist') }}">Watchlist</a> &mdash; {{ watchlist_count }} movie{{ 's' if watchlist_count != 1 else '' }}</li>
+              <li>Liked reviews &mdash; {{ liked_count }}</li>
+            </ul>
+          </div>
+
+          {% if favourite_genres %}
+            <div class="card-cinema profile-side-card">
+              <p class="eyebrow">Tastes</p>
+              <h2 class="sidebar-title">Favourite genres</h2>
+              <ul class="profile-side-list">
+                {% for name, count in favourite_genres %}
+                  <li>{{ name }} &mdash; {{ count }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
         </aside>
       </div>
     </section>

--- a/app/templates/other_profile.html
+++ b/app/templates/other_profile.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Movie Star | Sarah K.</title>
+  <title>Movie Star | {{ user.username }}</title>
+  {# CSRF token exposed for AJAX (read in JS via meta[name=csrf-token].content) #}
+  <meta name="csrf-token" content="{{ csrf_token() }}" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/other_profile.css') }}" />
@@ -14,13 +16,18 @@
       <a href="{{ url_for('home') }}" class="nav-logo">Movie Star</a>
 
       <ul class="nav-links">
-        <li><a href="{{ url_for('home') }}" data-auth-nav="logged-in">Home</a></li>
-        <li><a href="{{ url_for('watchlist') }}" data-auth-nav="logged-in">Watchlist</a></li>
+        <li><a href="{{ url_for('home') }}">Home</a></li>
+        <li><a href="{{ url_for('watchlist') }}">Watchlist</a></li>
       </ul>
 
       <div class="nav-actions profile-nav-actions">
-        <a href="{{ url_for('profile') }}" class="btn-primary" data-auth-nav="logged-in">Profile</a>
-        <a href="{{ url_for('logout') }}" id="other-profile-logout-btn" class="btn-ghost">Logout</a>
+        {% if current_user.is_authenticated %}
+          <a href="{{ url_for('profile') }}" class="btn-primary">Profile</a>
+          <a href="{{ url_for('logout') }}" id="other-profile-logout-btn" class="btn-ghost">Logout</a>
+        {% else %}
+          <a href="{{ url_for('auth') }}" class="btn-ghost">Login</a>
+          <a href="{{ url_for('auth') }}" class="btn-primary">Sign Up</a>
+        {% endif %}
       </div>
     </div>
   </nav>
@@ -30,34 +37,53 @@
       <div class="page-container">
         <div class="card-cinema profile-hero-card">
           <div class="profile-avatar-wrap">
-            <img src="https://i.pravatar.cc/120?img=5" alt="Sarah K. avatar" class="profile-avatar" />
+            {% if user.avatar_path %}
+              <img src="{{ user.avatar_path }}" alt="{{ user.username }} avatar" class="profile-avatar" />
+            {% else %}
+              <img src="https://i.pravatar.cc/120?u={{ user.id }}" alt="{{ user.username }} avatar" class="profile-avatar" />
+            {% endif %}
           </div>
 
           <div class="profile-hero-copy">
             <p class="eyebrow">Community Member</p>
-            <h1 class="profile-name">Sarah K.</h1>
-            <p class="profile-meta">@sarah_k / Joined January 2023</p>
-            <p class="profile-bio">
-              Film obsessive, slow-cinema defender, and frequent reviewer. Usually writing about science fiction,
-              character drama, and ambitious auteur releases.
+            <h1 class="profile-name">{{ user.username }}</h1>
+            <p class="profile-meta">
+              @{{ user.username }}
+              {% if user.created_at %}
+                &middot; Joined {{ user.created_at.strftime('%B %Y') }}
+              {% endif %}
             </p>
+            {% if user.bio %}
+              <p class="profile-bio">{{ user.bio }}</p>
+            {% endif %}
           </div>
 
           <div class="profile-hero-actions">
-            <button id="follow-btn" class="btn-primary" type="button">Follow</button>
+            {% if current_user.is_authenticated %}
+              <button
+                id="follow-btn"
+                class="btn-primary follow-btn {% if is_following %}is-following{% endif %}"
+                type="button"
+                data-user-id="{{ user.id }}"
+              >
+                {% if is_following %}Following{% else %}Follow{% endif %}
+              </button>
+            {% else %}
+              <a href="{{ url_for('auth') }}" class="btn-primary">Log in to follow</a>
+            {% endif %}
           </div>
 
           <div class="profile-stats">
             <div class="profile-stat">
-              <span class="profile-stat-value">142</span>
+              <span class="profile-stat-value">{{ user.review_count }}</span>
               <span class="profile-stat-label">Reviews</span>
             </div>
             <div class="profile-stat">
-              <span class="profile-stat-value">381</span>
+              <span class="profile-stat-value">{{ user.following_count }}</span>
               <span class="profile-stat-label">Following</span>
             </div>
             <div class="profile-stat">
-              <span id="follower-count" class="profile-stat-value">924</span>
+              <span id="follower-count" class="profile-stat-value">{{ user.follower_count }}</span>
               <span class="profile-stat-label">Followers</span>
             </div>
           </div>
@@ -73,87 +99,50 @@
               <p class="eyebrow">Public Activity</p>
               <h2 class="section-title">Recent Reviews</h2>
             </div>
-            <p class="section-copy">A simplified public review feed for this user profile prototype.</p>
+            <p class="section-copy">
+              {% if reviews %}
+                Showing {{ reviews | length }} public review{{ 's' if reviews | length != 1 else '' }}.
+              {% else %}
+                {{ user.username }} hasn't posted any reviews yet.
+              {% endif %}
+            </p>
           </div>
 
           <div class="profile-review-list">
-            <article class="card-cinema profile-review-card">
-              <div class="profile-review-poster-wrap">
-                <img src="https://image.tmdb.org/t/p/w92/AmR3JG1VQVxU8TfAvljUhfSFUOx.jpg" alt="Dune: Part Two poster" class="profile-review-poster" />
-              </div>
-              <div class="profile-review-body">
-                <div class="profile-review-top">
-                  <div>
-                    <h3 class="profile-review-title">Dune: Part Two</h3>
-                    <p class="profile-review-meta">2024 / Sci-Fi</p>
+            {% for review in reviews %}
+              {% set movie = review.movie %}
+              <article class="card-cinema profile-review-card" data-review-id="{{ review.id }}">
+                <a href="{{ url_for('movie', movie_id=movie.id) }}" class="profile-review-poster-wrap">
+                  {% if movie.poster_path %}
+                    <img src="{{ movie.poster_path }}" alt="{{ movie.title }} poster" class="profile-review-poster" />
+                  {% else %}
+                    <img src="https://picsum.photos/seed/op{{ movie.id }}/92/138" alt="{{ movie.title }} poster" class="profile-review-poster" />
+                  {% endif %}
+                </a>
+                <div class="profile-review-body">
+                  <div class="profile-review-top">
+                    <div>
+                      <h3 class="profile-review-title">
+                        <a href="{{ url_for('movie', movie_id=movie.id) }}">{{ movie.title }}</a>
+                      </h3>
+                      <p class="profile-review-meta">
+                        {% if movie.release_year %}{{ movie.release_year }}{% endif %}
+                        {% if movie.primary_genre %} / {{ movie.primary_genre }}{% endif %}
+                        {% if movie.director_name %} / {{ movie.director_name }}{% endif %}
+                      </p>
+                    </div>
+                    <span class="profile-review-rating">&#9733; {{ review.rating }}/10</span>
                   </div>
-                  <span class="profile-review-rating">&#9733; 5/5</span>
-                </div>
-                <p class="profile-review-copy">
-                  Villeneuve has outdone himself. The scale is immense, but the character work still lands.
-                  This is blockbuster filmmaking with real control and confidence.
-                </p>
-                <div class="profile-review-footer">
-                  <span class="profile-review-date">10 March 2024</span>
-                  <button class="like-btn" type="button" data-like-btn>
-                    <span class="like-btn-label">Like</span>
-                    <span class="like-count">24</span>
-                  </button>
-                </div>
-              </div>
-            </article>
-
-            <article class="card-cinema profile-review-card">
-              <div class="profile-review-poster-wrap">
-                <img src="https://image.tmdb.org/t/p/w92/wTnV3PCVW5O92JMrFvvrRcV39RU.jpg" alt="Past Lives poster" class="profile-review-poster" />
-              </div>
-              <div class="profile-review-body">
-                <div class="profile-review-top">
-                  <div>
-                    <h3 class="profile-review-title">Past Lives</h3>
-                    <p class="profile-review-meta">2023 / Romance</p>
+                  <p class="profile-review-copy">{{ review.body }}</p>
+                  <div class="profile-review-footer">
+                    <span class="profile-review-date">{{ review.created_at.strftime('%d %B %Y') }}</span>
+                    <span class="profile-review-likes">
+                      {{ review.like_count }} like{{ 's' if review.like_count != 1 else '' }}
+                    </span>
                   </div>
-                  <span class="profile-review-rating">&#9733; 5/5</span>
                 </div>
-                <p class="profile-review-copy">
-                  One of the most quietly devastating films in years. Nothing is overstated, and that restraint is exactly
-                  what makes the ending hit so hard.
-                </p>
-                <div class="profile-review-footer">
-                  <span class="profile-review-date">4 February 2024</span>
-                  <button class="like-btn" type="button" data-like-btn>
-                    <span class="like-btn-label">Like</span>
-                    <span class="like-count">31</span>
-                  </button>
-                </div>
-              </div>
-            </article>
-
-            <article class="card-cinema profile-review-card">
-              <div class="profile-review-poster-wrap">
-                <img src="https://image.tmdb.org/t/p/w92/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg" alt="Interstellar poster" class="profile-review-poster" />
-              </div>
-              <div class="profile-review-body">
-                <div class="profile-review-top">
-                  <div>
-                    <h3 class="profile-review-title">Interstellar</h3>
-                    <p class="profile-review-meta">2014 / Sci-Fi</p>
-                  </div>
-                  <span class="profile-review-rating">&#9733; 5/5</span>
-                </div>
-                <p class="profile-review-copy">
-                  Still one of the clearest examples of spectacle and feeling working together. I revisit it often and it
-                  still feels huge, sincere, and emotionally direct.
-                </p>
-                <div class="profile-review-footer">
-                  <span class="profile-review-date">15 December 2023</span>
-                  <button class="like-btn" type="button" data-like-btn>
-                    <span class="like-btn-label">Like</span>
-                    <span class="like-count">48</span>
-                  </button>
-                </div>
-              </div>
-            </article>
+              </article>
+            {% endfor %}
           </div>
         </div>
 
@@ -162,10 +151,16 @@
             <p class="eyebrow">Overview</p>
             <h2 class="sidebar-title">Average Rating</h2>
             <div class="sidebar-rating-row">
-              <span class="sidebar-rating-value">4.4</span>
-              <span class="sidebar-rating-total">/ 5</span>
+              {% if user.average_rating is not none %}
+                <span class="sidebar-rating-value">{{ '%.1f' % user.average_rating }}</span>
+                <span class="sidebar-rating-total">/ 10</span>
+              {% else %}
+                <span class="sidebar-rating-value">—</span>
+              {% endif %}
             </div>
-            <p class="sidebar-copy">Based on 142 public reviews.</p>
+            <p class="sidebar-copy">
+              Based on {{ user.review_count }} public review{{ 's' if user.review_count != 1 else '' }}.
+            </p>
           </div>
         </aside>
       </div>

--- a/app/templates/profile_edit.html
+++ b/app/templates/profile_edit.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Movie Star | Edit Profile</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/my_profile.css') }}" />
+</head>
+<body class="profile-page">
+  <nav class="navbar-cinema" id="navbar">
+    <div class="page-container profile-nav-wrap">
+      <a href="{{ url_for('home') }}" class="nav-logo">Movie Star</a>
+
+      <ul class="nav-links">
+        <li><a href="{{ url_for('home') }}">Home</a></li>
+        <li><a href="{{ url_for('watchlist') }}">Watchlist</a></li>
+      </ul>
+
+      <div class="nav-actions profile-nav-actions">
+        <a href="{{ url_for('profile') }}" class="btn-primary">Profile</a>
+        <a href="{{ url_for('logout') }}" class="btn-ghost">Logout</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="profile-main">
+    <section class="profile-hero">
+      <div class="page-container">
+        <div class="card-cinema profile-hero-card profile-edit-card">
+          <header class="profile-edit-header">
+            <p class="eyebrow">Account</p>
+            <h1 class="profile-name">Edit your profile</h1>
+            <p class="profile-meta">
+              Change your display name, write a short bio, or update your avatar URL.
+            </p>
+          </header>
+
+          {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+              <ul class="profile-flash-list">
+                {% for category, msg in messages %}
+                  <li class="profile-flash profile-flash-{{ category }}">{{ msg }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          {% endwith %}
+
+          <form
+            action="{{ url_for('profile_edit') }}"
+            method="post"
+            class="profile-edit-form"
+            novalidate
+          >
+            {{ form.hidden_tag() }}
+
+            <div class="review-field-block">
+              <label class="review-field-label" for="username">Username</label>
+              {{ form.username(
+                id="username",
+                class_="field-input",
+                placeholder="Your username",
+                maxlength=64,
+                required=true
+              ) }}
+              {% for err in form.username.errors %}
+                <p class="form-error">{{ err }}</p>
+              {% endfor %}
+            </div>
+
+            <div class="review-field-block">
+              <label class="review-field-label" for="bio">Bio</label>
+              {{ form.bio(
+                id="bio",
+                class_="field-input movie-review-input movie-review-textarea",
+                rows=4,
+                maxlength=500,
+                placeholder="Tell other film lovers what you watch."
+              ) }}
+              {% for err in form.bio.errors %}
+                <p class="form-error">{{ err }}</p>
+              {% endfor %}
+            </div>
+
+            <div class="review-field-block">
+              <label class="review-field-label" for="avatar_path">Avatar URL (optional)</label>
+              {{ form.avatar_path(
+                id="avatar_path",
+                class_="field-input",
+                placeholder="https://...",
+                maxlength=255
+              ) }}
+              {% for err in form.avatar_path.errors %}
+                <p class="form-error">{{ err }}</p>
+              {% endfor %}
+              <p class="form-hint">Leave blank to use the default avatar.</p>
+            </div>
+
+            <div class="review-actions-row review-actions-row-end">
+              <a href="{{ url_for('profile') }}" class="btn-ghost">Cancel</a>
+              {{ form.submit(class_="btn-primary movie-submit-btn") }}
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="page-container footer-note">&copy; 2026 Movie Star. Movie nights start here.</div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What this does

Three modules in one PR, each landed as a single self-contained commit:

- **Likes** — AJAX like/unlike on any review.
- **Comments** — Threaded comments on reviews (top-level + one-level replies), with soft-delete that preserves thread structure.
- **Profile** — Own + public profile pages backed by real DB data, edit-profile form, and follow/unfollow.

Closes #44
Closes #45
Closes #46

## Endpoints shipped

| Method | URL | Login required | Purpose |
|---|---|---|---|
| `POST` | `/review/<review_id>/like` | Yes | Like a review (idempotent) |
| `POST` | `/review/<review_id>/unlike` | Yes | Remove your like |
| `POST` | `/review/<review_id>/comment` | Yes | Top-level comment on a review |
| `POST` | `/comment/<comment_id>/reply` | Yes | Reply to a comment |
| `POST` | `/comment/<comment_id>/delete` | Yes | Soft-delete one of your own comments |
| `GET`  | `/profile` (rewritten) | Yes | Own profile with real data |
| `GET`  | `/user/<user_id>` (rewritten) | No | Public profile of any user |
| `GET`  | `/profile/edit` | Yes | Edit-profile form |
| `POST` | `/profile/edit` | Yes | Save profile changes |
| `POST` | `/user/<user_id>/follow` | Yes | Follow another user |
| `POST` | `/user/<user_id>/unfollow` | Yes | Unfollow another user |

All POST endpoints return JSON (where AJAX-consumed) and require an `X-CSRFToken` header from the `<meta name="csrf-token">` tag in the page.

## Security

- `@login_required` on every POST endpoint.
- `user_id` always sourced from `current_user.id`, never from request body or URL.
- **Comment delete** + **review like/unlike on someone else's review**: ownership / scope enforced at the route level.
- **Comment delete** uses ownership check:
```python
  if comment.user_id != current_user.id:
      abort(403)
```
- **Follow yourself**: rejected with 400.
- **Username change** on profile edit checks uniqueness at the route level; 409 on clash.
- All POST/PUT/PATCH/DELETE are CSRF protected (`CSRFProtect` from Module D).

## Soft-delete behaviour for comments

Comments are **soft-deleted** (`is_deleted=True` flag instead of row removal) so that child replies stay reachable. The template:
- Renders `[comment removed]` via `ReviewComment.display_body` for soft-deleted rows.
- Keeps a deleted parent visible if any of its replies are still alive.
- Collapses a deleted parent with no living replies (nothing rendered).

## Commits in this PR

| # | Commit | Scope |
|---|---|---|
| 1 | `feat(likes): add like/unlike endpoints + button on review cards` | 3 files, 99 insertions |
| 2 | `feat(comments): threaded comments on reviews (create / reply / delete)` | 4 files, 310 insertions |
| 3 | `feat(profile): user profile pages + edit + follow/unfollow` | 7 files, 597 insertions, 304 deletions |

## Files changed

- `app/forms.py` — added `CommentForm` and `ProfileEditForm`.
- `app/routes.py` — eleven new/rewritten route handlers + JSON helpers (`_comment_to_json`, `_top_genres_for`).
- `app/templates/movie_page.html` — Like buttons on every review card; two Jinja macros (`render_comment_card`, `render_comments_section`) for threaded comments shared between Your Review and Community Reviews.
- `app/templates/my_profile.html` — full rewrite. Real user data, real reviews list, average rating, library counts, favourite-genre breakdown.
- `app/templates/other_profile.html` — full rewrite. Real reviews list, Follow/Unfollow button with `data-user-id` hook.
- **NEW** `app/templates/profile_edit.html` — standalone edit form with FlaskForm rendering, flash messages, error display.
- `app/static/js/movie_page.js` — Like AJAX toggle, comment submit/reply/delete, reply form toggle.
- `app/static/js/my_profile.js` — gutted; removed all the legacy localStorage('movieStarDemoAuth') demo logic, only the navbar scroll effect remains.
- `app/static/js/other_profile.js` — rewritten as a small AJAX client for the Follow/Unfollow button.

## Manual testing

- **Likes** — like/unlike round-trip on the movie page, count updates inline; idempotent re-like returns 200 with `already_liked: true`.
- **Comments** — post top-level, reply (toggle inline form), soft-delete own comment → renders as `[comment removed]` with replies still visible; deleting the last reply collapses the parent placeholder.
- **Profile** — own profile shows real reviews, library counts, average rating, favourite genres; other profile shows Follow button → click toggles to Following and increments count via AJAX.
- **Edit profile** — form pre-fills with current values; valid edit redirects to `/profile`; username collision returns 409 with inline error; empty username returns 400.
- **Security** — non-owner deleting a comment returns 403; following yourself returns 400; AJAX without `X-CSRFToken` returns 400.

## Notes for future polish

- Comments currently render at most 2 levels (top + flat replies). The model supports unbounded nesting if a future iteration wants deeper threads.
- Profile edit is a separate page rather than a modal — easier to maintain and works without JS. Modal version could land later if the design team wants it.
- "Liked Reviews" tab on my_profile was scoped out of this PR — the count is shown but a dedicated view is left for a follow-up.