### PR TITLE
fix(home): remove non-functional filter bar buttons

### DIFF
--- a/app/templates/home_page.html
+++ b/app/templates/home_page.html
@@ -62,15 +62,18 @@
   <section class="page-section">
     <div class="page-container">
       <div class="section-head">
-        <div class="filter-bar">
-          <a href="{{ url_for('search') }}" class="btn-nav">Genre</a>
-          <a href="{{ url_for('search') }}" class="btn-nav">Release Year</a>
-          <a href="{{ url_for('search') }}" class="btn-nav">Highest Rating</a>
-          <a href="{{ url_for('search') }}" class="btn-ghost">Clear Filters</a>
-        </div>
         <div>
           <h2 class="section-title">Highest Rating Movies</h2>
           <p class="section-subtitle">Curated films with the highest score from our community.</p>
+        </div>
+        {#
+          The old "Genre / Release Year / Highest Rating / Clear Filters"
+          row was removed because every button just linked to /search
+          without pre-filling anything, which set false expectations.
+          One honest link to the full search page replaces them.
+        #}
+        <div class="filter-bar">
+          <a href="{{ url_for('search') }}" class="btn-nav">Browse all movies</a>
         </div>
       </div>
 


### PR DESCRIPTION
## What this changes

The "Highest Rating Movies" section on the home page had a 4-button filter bar:

```
[ Genre ] [ Release Year ] [ Highest Rating ] [ Clear Filters ]
```

All four buttons linked to `/search` with no query parameters pre-filled, so clicking any of them was indistinguishable from clicking any other — and set false expectations that the user was about to see an active filter view that never materialised.

### Removed because they were misleading
- **"Genre"** and **"Release Year"** — redundant with the `/search` page's sidebar, which already has dynamic genre chips + year input.
- **"Highest Rating"** — redundant with the section title right below it (the section is *already* the highest rating movies).
- **"Clear Filters"** — meaningless on the home page where no filter is active.

### Replaced with
A single honest **"Browse all movies"** link that goes to `/search`, where the actual filter UI lives. Also swapped the order so the section title sits on the left (primary content) and the link sits on the right (secondary action), which reads more naturally.

## Files changed

- `app/templates/home_page.html` — replace 4 `btn-nav` / `btn-ghost` links with 1 `btn-nav` "Browse all movies" link inside the same `.filter-bar` container.

## Why not make them functional instead?

Each button would need its own dropdown or input on the home page (genre picker, year selector, rating threshold), plus JS to apply the filter and navigate. That's a meaningful UI redesign for a row of buttons that already has a perfectly good home on the `/search` page. Removing them keeps the home page focused on browsing rather than filtering.