### PR TITLE
Redirect logout to auth page

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -110,4 +110,4 @@ def signup():
 def logout():
     logout_user()
     flash("You have been logged out.", "success")
-    return redirect(url_for("home"))
+    return redirect(url_for("auth"))


### PR DESCRIPTION
## What this PR does

This PR improves the logout flow so users see the logout confirmation immediately on the auth page.

## Changes made

- Updated the logout redirect to send users to `/auth` after logging out.
- Kept the existing “You have been logged out.” flash message.
- Removed the home-page flash display block that was previously added for logout feedback.
- Preserved existing login, signup, session, and CSRF behaviour.

## Notes

The auth form may still show autofilled email/password values because of the browser or password manager. This is expected browser behaviour and does not mean the user is still logged in.

## Manual testing

- Logged in with an existing account.
- Clicked Logout.
- Confirmed the user is redirected to `/auth`.
- Confirmed “You have been logged out.” appears immediately.
- Confirmed the navbar shows logged-out state.
- Confirmed the message does not appear later unexpectedly.

Closes #55 