### PR TITLE
Move secret key to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SECRET_KEY=replace-with-your-own-secret-key
+DATABASE_URL=
+OMDB_KEY=

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,25 @@
+import os
 from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+load_dotenv(PROJECT_ROOT / ".env")
+
+SECRET_KEY_VALUE = os.environ.get("SECRET_KEY")
+if not SECRET_KEY_VALUE:
+    raise RuntimeError(
+        "SECRET_KEY is not set. Create a .env file in the project root with "
+        "SECRET_KEY set to a secure value."
+    )
+
+DATABASE_URL = os.environ.get("DATABASE_URL") or (
+    f"sqlite:///{(Path(__file__).resolve().parent / 'app.db').as_posix()}"
+)
 
 
 class Config:
-    SECRET_KEY = "dev-secret-key"
-    SQLALCHEMY_DATABASE_URI = f"sqlite:///{(Path(__file__).resolve().parent / 'app.db').as_posix()}"
+    SECRET_KEY = SECRET_KEY_VALUE
+    SQLALCHEMY_DATABASE_URI = DATABASE_URL
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 Mako==1.3.12
 MarkupSafe==3.0.3
+python-dotenv
 SQLAlchemy==2.0.49
 typing_extensions==4.15.0
 Werkzeug==3.1.8


### PR DESCRIPTION
## What this PR does

This PR updates the Flask configuration so the app loads sensitive configuration values from environment variables instead of using a hardcoded secret key.

## Changes made

- Updated `config.py` to load `.env` from the project root.
- Updated `SECRET_KEY` to come from the environment.
- Added a clear error if `SECRET_KEY` is missing.
- Kept `DATABASE_URL` optional.
- Kept the local SQLite `app.db` fallback when `DATABASE_URL` is blank or missing.
- Added `.env` to `.gitignore`.
- Added `.env.example` with placeholder values only.
- Added/kept `python-dotenv` in requirements.

## Security notes

- Real secret keys should be stored only in each developer’s local `.env` file.
- `.env` should not be committed to GitHub.
- `.env.example` is safe to commit because it only contains placeholders.
- Each teammate can generate their own local `SECRET_KEY`.

## Manual testing

- Created a local `.env` file with a generated `SECRET_KEY`.
- Ran `python run.py`.
- Confirmed the app starts normally.
- Confirmed login/logout/session behaviour still works.
- Confirmed the app falls back to local SQLite when `DATABASE_URL` is blank.
- Confirmed `.env` is not tracked by Git.

Closes #59 