### PR TITLE
Fix watchlist rating badge by moving .card-badge to shared style.css

### DIFF
--- a/app/static/css/home_page.css
+++ b/app/static/css/home_page.css
@@ -150,21 +150,6 @@
   gap: 10px;
 }
 
-.card-badge {
-  position: absolute;
-  top: 18px;
-  right: 18px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--gold);
-  color: var(--dark);
-  padding: 10px 14px;
-  border-radius: 9999px;
-  font-weight: 700;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
-}
-
 .footer-note {
   text-align: center;
   font-size: 0.9rem;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -247,6 +247,22 @@ body::before {
   opacity: 1;
 }
 
+/* Rating pill (gold badge) shown on movie/watchlist/search cards. */
+.card-badge {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--gold);
+  color: var(--dark);
+  padding: 10px 14px;
+  border-radius: 9999px;
+  font-weight: 700;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
 /* Movie card */
 .movie-card img {
   display: block;


### PR DESCRIPTION
## Summary
The rating pill (★ + number) on the watchlist page was rendering as
plain white text instead of the gold badge used on the home page. Fix
is purely CSS — move the `.card-badge` rule out of `home_page.css` and
into the shared `style.css` so every page that uses the class
(watchlist, search results, etc.) picks it up automatically.

Closes #70 

## Root cause
- Both `home_page.html` and `watchlist_page.html` already use
  `<div class="card-badge">…</div>` for the rating.
- The `.card-badge` rule only existed in `app/static/css/home_page.css`.
- The watchlist page loads `style.css` + `watchlist_page.css` only — it
  never loads `home_page.css`, so the class matched no rules and fell
  back to default white text.

## Commits
1. **Add shared `.card-badge` rule to `style.css`** — adds the gold
   pill styling to the shared stylesheet every page already loads.
   After this commit the bug is fixed.
2. **Remove duplicate `.card-badge` rule from `home_page.css`** —
   removes the now-redundant copy. Each commit leaves the app in a
   working state on its own.

## Test plan
- [x] Home → "Highest Rating Movies" still shows gold pill badges (no regression)
- [x] `/watchlist` now shows gold pill badges matching the home page
- [ ] Search results page (if it uses `.card-badge`) — bonus benefit, please eyeball

## How to verify locally
1. Pull this branch: `git fetch && git checkout fix/watchlist-rating-badge`
2. Run `python run.py` and hard-refresh the browser (`⌘+Shift+R` / `Ctrl+Shift+R`) to bypass the CSS cache
3. Log in as `alex@example.com` / `password123` and visit `/watchlist`
4. Confirm the rating on each card is a gold pill in the top-right of the poster
