### PR TITLE
Fix watchlist counter not updating after AJAX remove

### DIFF
--- a/app/static/js/watchlist_page.js
+++ b/app/static/js/watchlist_page.js
@@ -51,6 +51,7 @@ function fadeAndRemove(card) {
   card.style.transform = 'scale(0.96)';
   window.setTimeout(() => {
     card.remove();
+    updateCount();
     // If that was the last card, reload to render the empty state from
     // the server template instead of patching the DOM by hand.
     if (!document.querySelector('.watchlist-card')) {

--- a/app/static/js/watchlist_page.js
+++ b/app/static/js/watchlist_page.js
@@ -38,6 +38,13 @@ async function postWatchlistRemove(movieId) {
   return { ok: response.ok, data };
 }
 
+function updateCount() {
+  const counter = document.querySelector('.sort-count');
+  if (!counter) return;
+  const count = document.querySelectorAll('.watchlist-card').length;
+  counter.textContent = `${count} movie${count !== 1 ? 's' : ''}`;
+}
+
 function fadeAndRemove(card) {
   card.style.transition = 'opacity 0.25s ease, transform 0.25s ease';
   card.style.opacity = '0';


### PR DESCRIPTION
## Summary
The "X MOVIES" counter on the watchlist page was stale after a card
was removed via the Remove button — the card disappeared but the
counter only refreshed on full page reload. Fix is purely client-side:
after a successful AJAX remove, recount the `.watchlist-card`
elements in the DOM and write the new value into `.sort-count`.

Closes #72

## Root cause
- `watchlist_page.js`'s `fadeAndRemove` removes the card from the DOM
  and reloads only when the watchlist becomes empty (to trigger the
  server-rendered empty-state hero).
- The `.sort-count` element rendered by `watchlist_page.html` shows
  `{{ watchlist_count }} movies` from the server — there was no
  client-side update path for the non-zero case.

## Commits
1. **Add `updateCount` helper.** Introduces a small helper that
   re-queries `.watchlist-card` elements and writes the new total
   into `.sort-count`, matching the server's "1 movie" / "N movies"
   pluralisation.
2. **Call `updateCount` after card removal.** Wires the helper into
   `fadeAndRemove`, right after `card.remove()` and before the
   existing empty-state reload check.

## What this preserves
- No HTML/template change — the existing `.sort-count` class was
  already a usable selector.
- No backend change.
- The initial server-side count render is left alone — JS only
  updates after AJAX.
- The existing empty-state pattern is unchanged: removing the last
  card still triggers a reload so the server-rendered empty-state
  hero takes over.

## Test plan
- [x] Load `/watchlist` with multiple cards → counter shows correct initial count
- [x] Remove a non-last card → counter ticks down immediately
- [x] Remove the last card → page reloads and empty-state hero appears
- [ ] Counter pluralisation: 1 card → "1 movie", >1 cards → "N movies"

## How to verify locally
1. `git fetch && git checkout fix/watchlist-counter`
2. `python run.py` and hard-refresh the browser (`⌘+Shift+R`)
3. Log in as `alex@example.com` / `password123`, ensure several items on watchlist
4. Click Remove on cards one at a time → confirm counter updates each time
